### PR TITLE
Command is still spoken if it is the first message

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -103,6 +103,11 @@ func (a *MainApp) startup(ctx context.Context) {
 	a.ctx = ctx
 
 	a.Client.OnPrivateMessage(func(message twitch.PrivateMessage) {
+		// Prevent the TTS from speaking commands.
+		if isACommandMessage(message.Message) {
+			return
+		}
+
 		//Prevent the tts repeat the las name
 		user := message.User.Name
 		textMessage := ""
@@ -112,7 +117,7 @@ func (a *MainApp) startup(ctx context.Context) {
 			lastUser = user
 			textMessage = fmt.Sprintf("%s ha dicho %s", user, message.Message)
 		}
-		if !a.Config.IsMutted(user) && !isACommandMessage(textMessage) {
+		if !a.Config.IsMutted(user) {
 			go a.Player.Add(textMessage)
 		}
 		runtime.EventsEmit(ctx, "OnNewMessage", message)


### PR DESCRIPTION
The test added in 3772e02cfae0df0c4efba7426441f6a026ce045e to avoid saying loud commands that start with ! is not actually working when it is the first message in a row sent by an user, because the textMessage variable gets "danirod_ ha dicho" as a preffix, therefore message[0] is never !, but the initial of the username. Extra messages actually get shutdown, but the first one is always spoken.

Instead, in this patch I make the handler give up as soon as possible if the message starts by !, before adding things to the variable. I've been testing this while live with multiple people in the chat and it seems to work.